### PR TITLE
Updated README with PSR-0 bullet point

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ To contribute, the following criteria needs to be fulfilled:
 * Pull requests should implement a boxed change
 * All code and documentation must follow the
 [PEAR coding standards](http://pear.php.net/manual/en/standards.php)
+* All classes must follow the [PSR-0 standard](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-0.md)
 * New features and bug fixes must have accompanying unit tests:
     * Positive tests
     * Negative tests


### PR DESCRIPTION
![The Ducktato](http://d24w6bsrhbeh9d.cloudfront.net/photo/6265017_460s.jpg)

I saw that you've added a section to your README about how to contribute, which is great. However, I noticed one thing that seems to be missing. In your composer.json file you declare that this project can be PSR-0 autoloaded, yet there is no requirement to follow the PSR-0 standard.

If you haven't taken a look at PSR-0 before, it's not that big of a deal. Since you're following the PEAR class naming standard, the PSR-0 standard only adds two more restrictions. It formalizes the file structure you're already using (replace underscores in class names with the directory separator), and it stipulates one class per file (which you're almost using, and PR #1 aims to remedy).
