### PR TITLE
Adding CURLOPT_TIMEOUT with the same timout as CURLOPT_CONNECTTIMEOUT.

### DIFF
--- a/src/Klarna/Checkout/HTTP/CURLTransport.php
+++ b/src/Klarna/Checkout/HTTP/CURLTransport.php
@@ -123,6 +123,7 @@ class Klarna_Checkout_HTTP_CURLTransport
 
         $curl->setOption(CURLOPT_RETURNTRANSFER, true);
         $curl->setOption(CURLOPT_CONNECTTIMEOUT, $this->timeout);
+        $curl->setOption(CURLOPT_TIMEOUT, $this->timeout);
 
         $curlHeaders = new Klarna_Checkout_HTTP_CURLHeaders();
         $curl->setOption(

--- a/tests/unit/HTTP/CURLTransportTest.php
+++ b/tests/unit/HTTP/CURLTransportTest.php
@@ -161,9 +161,13 @@ class Klarna_Checkout_HTTP_CURLTransportTest extends PHPUnit_Framework_TestCase
             $handle->options[CURLOPT_POST]
         );
         $this->assertTrue($handle->options[CURLOPT_RETURNTRANSFER]);
-        $this->assertEquals(
+        $this->assertSame(
             $this->http->getTimeout(),
-            $handle->options[CURLOPT_RETURNTRANSFER]
+            $handle->options[CURLOPT_CONNECTTIMEOUT]
+        );
+        $this->assertSame(
+            $this->http->getTimeout(),
+            $handle->options[CURLOPT_TIMEOUT]
         );
     }
 
@@ -187,9 +191,13 @@ class Klarna_Checkout_HTTP_CURLTransportTest extends PHPUnit_Framework_TestCase
             array_key_exists(CURLOPT_POST, $handle->options) &&
             $handle->options[CURLOPT_POST]
         );
-        $this->assertEquals(
+        $this->assertSame(
             $this->http->getTimeout(),
-            $handle->options[CURLOPT_RETURNTRANSFER]
+            $handle->options[CURLOPT_CONNECTTIMEOUT]
+        );
+        $this->assertSame(
+            $this->http->getTimeout(),
+            $handle->options[CURLOPT_TIMEOUT]
         );
     }
 


### PR DESCRIPTION
This change adds the CURLOPT_TIMEOUT option, so that a hanging
connection won't hang indefinately.

It adds test for this option, and also fixes the test for
CURLOPT_CONNECTTIMEOUT (that was typoed into CURLOPT_RETURNTRANSFER
and missed because of assertEquals instead of assertSame).
