### PR TITLE
Add ability to instantiate order with an order uri

### DIFF
--- a/src/Klarna/Checkout/DomainMismatchException.php
+++ b/src/Klarna/Checkout/DomainMismatchException.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Copyright 2015 Klarna AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * File containing the Klarna_Checkout_ConnectionErrorException class
+ *
+ * PHP version 5.3
+ *
+ * @category  Payment
+ * @package   Klarna_Checkout
+ * @author    Klarna <support@klarna.com>
+ * @copyright 2015 Klarna AB
+ * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache license v2.0
+ * @link      http://developers.klarna.com/
+ */
+
+
+/**
+ * Domain exception
+ *
+ * @category  Payment
+ * @package   Klarna_Checkout
+ * @author    Ulrik Långström <ulrik.langstrom@sitedirect.se>
+ * @copyright 2015 Klarna AB
+ * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache license v2.0
+ * @link      http://developers.klarna.com/
+ */
+class Klarna_Checkout_DomainMismatchException extends Klarna_Checkout_Exception
+{
+
+}

--- a/tests/unit/OrderTest.php
+++ b/tests/unit/OrderTest.php
@@ -59,4 +59,44 @@ class Klarna_Checkout_OrderTest extends PHPUnit_Framework_TestCase
             $order->getLocation()
         );
     }
+
+    /**
+     * Test that an uri can be passed to the constructor
+     *
+     * @return void
+     */
+    public function testUseOrderUriGivenIfMatchingConnector()
+    {
+        $mock = $this->getMock('Klarna_Checkout_ConnectorInterface');
+        $mock->expects($this->once())
+            ->method('getDomain')
+            ->willReturn('https://whatever.com');
+
+        $order = new Klarna_Checkout_Order(
+            $mock, 'https://whatever.com/checkout/orders/foobar'
+        );
+
+        $this->assertEquals(
+            'https://whatever.com/checkout/orders/foobar',
+            $order->getLocation()
+        );
+    }
+
+    /**
+     * Test that an uri thar doesn't match the expected domain throws an exception
+     *
+     * @expectedException Klarna_Checkout_DomainMismatchException
+     */
+    public function testThrowExceptionGivenIfNonMatchingConnector()
+    {
+        $mock = $this->getMock('Klarna_Checkout_ConnectorInterface');
+        $mock->expects($this->once())
+            ->method('getDomain')
+            ->willReturn('https://something.else');
+
+        new Klarna_Checkout_Order(
+            $mock, 'https://whatever.com/checkout/orders/foobar'
+        );
+
+    }
 }


### PR DESCRIPTION
In updating from v1.2 to v4.0 of this library, the ability to pass in the order uri returned from the callback was lost. This seems weird, as there isn't anything else one can use to match payment to order.

This pull request restores that ability and adds a more specific exception for when the wrong domain is used.
