### PR TITLE
Php version less then 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "Apache-2.0",
     "type": "library",
     "require": {
-        "php": ">=5.3.0",
+        "php": ">=5.3.0 <7.0",
         "ext-curl": "*"
     },
     "require-dev": {


### PR DESCRIPTION
Because php 7 is not supported (Source: https://developers.klarna.com/en/se/kco-v2/download/php)
